### PR TITLE
Fix LCD_RTS.{h,cpp} for case-sensitive systems.

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1541,7 +1541,7 @@
  *     |    [-]    |
  *     O-- FRONT --+
  */
-#define NOZZLE_TO_PROBE_OFFSET { 0, 25, 0 }
+#define NOZZLE_TO_PROBE_OFFSET { -2.7, 28.32, -1.75 }
 
 // Most probes should stay away from the edges of the bed, but
 // with NOZZLE_AS_PROBE this can be negative for a wider probing area.

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1226,7 +1226,7 @@
  * Override with M92
  *                                      X, Y, Z [, I [, J [, K...]]], E0 [, E1[, E2...]]
  */
-#define DEFAULT_AXIS_STEPS_PER_UNIT   { 64, 80, 400, 415, 415 }
+#define DEFAULT_AXIS_STEPS_PER_UNIT   { 63.95, 79.87, 399, 447, 415 }
 
 /**
  * Default Max Feed Rate (linear=mm/s, rotational=°/s)

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -667,9 +667,9 @@
   #if ENABLED(PID_PARAMS_PER_HOTEND)
     // Specify up to one value per hotend here, according to your setup.
     // If there are fewer values, the last one applies to the remaining hotends.
-    #define DEFAULT_Kp_LIST {  22.20,  22.20 }
-    #define DEFAULT_Ki_LIST {   1.08,   1.08 }
-    #define DEFAULT_Kd_LIST { 114.00, 114.00 }
+    #define DEFAULT_Kp_LIST {  34.60,  35.85 }
+    #define DEFAULT_Ki_LIST {   4.32,   4.39 }
+    #define DEFAULT_Kd_LIST {  69.19,  73.13 }
   #else
     #define DEFAULT_Kp  23.81
     #define DEFAULT_Ki   1.93

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -756,9 +756,9 @@
 
   // 120V 250W silicone heater into 4mm borosilicate (MendelMax 1.5+)
   // from FOPDT model - kp=.39 Tp=405 Tdead=66, Tc set to 79.2, aggressive factor of .15 (vs .1, 1, 10)
-  #define DEFAULT_bedKp 312.84
-  #define DEFAULT_bedKi 52.04
-  #define DEFAULT_bedKd 1253.64
+  #define DEFAULT_bedKp 238.38
+  #define DEFAULT_bedKi 44.47
+  #define DEFAULT_bedKd 851.81
 
   // FIND YOUR OWN: "M303 E-1 C8 S90" to run autotune on the bed at 90 degreesC for 8 cycles.
 #endif // PIDTEMPBED

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -2279,10 +2279,10 @@
 #define PREHEAT_1_FAN_SPEED      0 // Value from 0 to 255
 
 #define PREHEAT_2_LABEL       "ABS"
-#define PREHEAT_2_TEMP_HOTEND 240
-#define PREHEAT_2_TEMP_BED     80
-#define PREHEAT_2_TEMP_CHAMBER 35
-#define PREHEAT_2_FAN_SPEED     0 // Value from 0 to 255
+#define PREHEAT_2_TEMP_HOTEND  240
+#define PREHEAT_2_TEMP_BED      80
+#define PREHEAT_2_TEMP_CHAMBER  35
+#define PREHEAT_2_FAN_SPEED      0 // Value from 0 to 255
 
 // @section motion
 

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1226,7 +1226,7 @@
  * Override with M92
  *                                      X, Y, Z [, I [, J [, K...]]], E0 [, E1[, E2...]]
  */
-#define DEFAULT_AXIS_STEPS_PER_UNIT   { 63.95, 79.87, 399, 447, 415 }
+#define DEFAULT_AXIS_STEPS_PER_UNIT   { 64.56, 80.66, 400.2, 447, 415 }
 
 /**
  * Default Max Feed Rate (linear=mm/s, rotational=°/s)

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -2272,11 +2272,11 @@
 //
 // Preheat Constants - Up to 10 are supported without changes
 //
-#define PREHEAT_1_LABEL       "PLA"
-#define PREHEAT_1_TEMP_HOTEND 200
-#define PREHEAT_1_TEMP_BED     60
-#define PREHEAT_1_TEMP_CHAMBER 35
-#define PREHEAT_1_FAN_SPEED     0 // Value from 0 to 255
+#define PREHEAT_1_LABEL       "TPU"
+#define PREHEAT_1_TEMP_HOTEND  205
+#define PREHEAT_1_TEMP_BED       0
+#define PREHEAT_1_TEMP_CHAMBER   0
+#define PREHEAT_1_FAN_SPEED      0 // Value from 0 to 255
 
 #define PREHEAT_2_LABEL       "ABS"
 #define PREHEAT_2_TEMP_HOTEND 240

--- a/Marlin/src/feature/powerloss.cpp
+++ b/Marlin/src/feature/powerloss.cpp
@@ -580,12 +580,12 @@ void PrintJobRecovery::resume() {
       dualXPrintingModeStatus = 0;
     }
 
-    gcode.process_subcommands_now(PSTR("G1 E3 F3000"));
+    gcode.process_subcommands_now(F("G1 E3 F3000"));
 
     save_dual_x_carriage_mode = dualXPrintingModeStatus;
     if(save_dual_x_carriage_mode == 1)
     {
-      gcode.process_subcommands_now(PSTR("M605 S1"));
+      gcode.process_subcommands_now(F("M605 S1"));
       if(info.active_extruder == 0)
       {
         sprintf_P(cmd, PSTR("T%i"), info.active_extruder);

--- a/Marlin/src/lcd/e3v2/creality/LCD_RTS.cpp
+++ b/Marlin/src/lcd/e3v2/creality/LCD_RTS.cpp
@@ -1,5 +1,5 @@
-#include "lcd_rts.h"
-#include <wstring.h>
+#include "LCD_RTS.h"
+#include <WString.h>
 #include <stdio.h>
 #include <string.h>
 #include <Arduino.h>

--- a/Marlin/src/lcd/e3v2/creality/LCD_RTS.h
+++ b/Marlin/src/lcd/e3v2/creality/LCD_RTS.h
@@ -3,7 +3,7 @@
 
 #include "../../../sd/cardreader.h"
 #include "string.h"
-#include <arduino.h>
+#include <Arduino.h>
 
 #include "../../../inc/MarlinConfig.h"
 


### PR DESCRIPTION

The firmware does not build on Linux due to incorrect case-sensitive includes.
This PR fixes the broken build.