### PR TITLE
Fix undefined behavior in powerloss.cpp.

### DIFF
--- a/Marlin/src/feature/powerloss.cpp
+++ b/Marlin/src/feature/powerloss.cpp
@@ -580,12 +580,12 @@ void PrintJobRecovery::resume() {
       dualXPrintingModeStatus = 0;
     }
 
-    gcode.process_subcommands_now(PSTR("G1 E3 F3000"));
+    gcode.process_subcommands_now(F("G1 E3 F3000"));
 
     save_dual_x_carriage_mode = dualXPrintingModeStatus;
     if(save_dual_x_carriage_mode == 1)
     {
-      gcode.process_subcommands_now(PSTR("M605 S1"));
+      gcode.process_subcommands_now(F("M605 S1"));
       if(info.active_extruder == 0)
       {
         sprintf_P(cmd, PSTR("T%i"), info.active_extruder);


### PR DESCRIPTION
### Description

`PSTR()` is only appropriate when passed to a printf()-style function, and will cause compiler warnings when passed to `char*` parameters.

Instead, the `F()` macro should be used in such scenarios.

### Benefits

Eliminates all current build warnings (and undefined behavior).
This makes the build output clean so new warnings are not accidentally ignored.