### PR TITLE
Force compiler warnings to fail the build for safety

### DIFF
--- a/Marlin/src/feature/powerloss.cpp
+++ b/Marlin/src/feature/powerloss.cpp
@@ -580,12 +580,12 @@ void PrintJobRecovery::resume() {
       dualXPrintingModeStatus = 0;
     }
 
-    gcode.process_subcommands_now(PSTR("G1 E3 F3000"));
+    gcode.process_subcommands_now(F("G1 E3 F3000"));
 
     save_dual_x_carriage_mode = dualXPrintingModeStatus;
     if(save_dual_x_carriage_mode == 1)
     {
-      gcode.process_subcommands_now(PSTR("M605 S1"));
+      gcode.process_subcommands_now(F("M605 S1"));
       if(info.active_extruder == 0)
       {
         sprintf_P(cmd, PSTR("T%i"), info.active_extruder);

--- a/Marlin/src/lcd/e3v2/creality/LCD_RTS.cpp
+++ b/Marlin/src/lcd/e3v2/creality/LCD_RTS.cpp
@@ -1,5 +1,5 @@
-#include "lcd_rts.h"
-#include <wstring.h>
+#include "LCD_RTS.h"
+#include <WString.h>
 #include <stdio.h>
 #include <string.h>
 #include <Arduino.h>

--- a/Marlin/src/lcd/e3v2/creality/LCD_RTS.h
+++ b/Marlin/src/lcd/e3v2/creality/LCD_RTS.h
@@ -3,7 +3,7 @@
 
 #include "../../../sd/cardreader.h"
 #include "string.h"
-#include <arduino.h>
+#include <Arduino.h>
 
 #include "../../../inc/MarlinConfig.h"
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -45,6 +45,7 @@ extra_configs =
 [common]
 build_flags        = -g3 -D__MARLIN_FIRMWARE__ -DNDEBUG
                      -fmax-errors=5
+                     -Werror
 extra_scripts      =
   pre:buildroot/share/PlatformIO/scripts/configuration.py
   pre:buildroot/share/PlatformIO/scripts/common-dependencies.py


### PR DESCRIPTION
### Description

This change adds the `-Werror` flag to turn all compiler warnings into errors, which will fail the build.

### Benefits

This will help prevent code with warnings from accidentally being pushed to the repository.

This is important for physical safety since compilers may emit code that does virtually anything in the presence of undefined behavior.

### Related Issues

https://github.com/johncarlson21/SV04-Marlin-2.1.x/pull/21
