### PR TITLE
Suicide switch; fix build on case-sensitive systems

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -60,11 +60,11 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "johncarlson21" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "hpa" // Who made the changes.
 #define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 #define MACVERSION      STRING_CONFIG_H_AUTHOR
 #define SOFTVERSION     SHORT_BUILD_VERSION
-#define CORP_WEBSITE    "johncarlson21 on GH"
+#define CORP_WEBSITE    "hpa@zytor.com"
 #define Screen_version  "!REFLASH SCREEN!"
 
 /**
@@ -1548,7 +1548,7 @@
 #define PROBING_MARGIN 25
 
 // X and Y axis travel speed (mm/min) between probes
-#define XY_PROBE_FEEDRATE (200*60) // John Carlson increase travel speed between probes 
+#define XY_PROBE_FEEDRATE (200*60) // John Carlson increase travel speed between probes
 
 // Feedrate (mm/min) for the first approach when double-probing (MULTIPLE_PROBING == 2)
 #define Z_PROBE_FEEDRATE_FAST (16*60) // John Carlson increase probe Z speed
@@ -1756,12 +1756,12 @@
 #define Y_BED_SIZE 302
 
 // Travel limits (linear=mm, rotational=°) after homing, corresponding to endstop positions.
-#define X_MIN_POS -62
+#define X_MIN_POS -64
 #define Y_MIN_POS 0
 #define Z_MIN_POS 0
 #define X_MAX_POS X_BED_SIZE
 #define Y_MAX_POS Y_BED_SIZE
-#define Z_MAX_POS 400
+#define Z_MAX_POS 402
 //#define I_MIN_POS 0
 //#define I_MAX_POS 50
 //#define J_MIN_POS 0
@@ -2302,8 +2302,8 @@
 #if ENABLED(NOZZLE_PARK_FEATURE)
   // Specify a park position as { X, Y, Z_raise }
   // #define NOZZLE_PARK_POINT { (X_BED_SIZE / 3), (Y_MAX_POS - 10), 20 }
-  #define NOZZLE_PARK_POINT { X_BED_SIZE, Y_MAX_POS, 20 }
-  #define NOZZLE_PARK_MOVE          0   // Park motion: 0 = XY Move, 1 = X Only, 2 = Y Only, 3 = X before Y, 4 = Y before X
+  #define NOZZLE_PARK_POINT { X_MIN_POS, Y_MAX_POS/2, 10 }
+  #define NOZZLE_PARK_MOVE          1   // Park motion: 0 = XY Move, 1 = X Only, 2 = Y Only, 3 = X before Y, 4 = Y before X
   #define NOZZLE_PARK_Z_RAISE_MIN   0   // (mm) Always raise Z by at least this distance
   #define NOZZLE_PARK_XY_FEEDRATE  100   // (mm/s) X and Y axes feedrate (also used for delta Z axis)
   #define NOZZLE_PARK_Z_FEEDRATE    5   // (mm/s) Z axis feedrate (not used for delta printers)

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -780,8 +780,8 @@
 #if ENABLED(DUAL_X_CARRIAGE)
   #define X1_MIN_POS X_MIN_POS    // Set to X_MIN_POS
   #define X1_MAX_POS X_BED_SIZE   // A max coordinate so the X1 carriage can't hit the parked X2 carriage
-  #define X2_MIN_POS     0        // A min coordinate so the X2 carriage can't hit the parked X1 carriage
-  #define X2_MAX_POS   362        // The max position of the X2 carriage, typically also the home position
+  #define X2_MIN_POS     2        // A min coordinate so the X2 carriage can't hit the parked X1 carriage
+  #define X2_MAX_POS   365        // The max position of the X2 carriage, typically also the home position
   #define X2_HOME_DIR    1        // Set to 1. The X2 carriage always homes to the max endstop position
   #define X2_HOME_POS X2_MAX_POS  // Default X2 home position. Set to X2_MAX_POS.
                                   // NOTE: For Dual X Carriage use M218 T1 Xn to override the X2_HOME_POS.
@@ -792,10 +792,10 @@
   #define DEFAULT_DUAL_X_CARRIAGE_MODE DXC_AUTO_PARK_MODE
 
   // Default x offset in duplication mode (typically set to half print bed width)
-  #define DEFAULT_DUPLICATION_X_OFFSET 150
+  #define DEFAULT_DUPLICATION_X_OFFSET 151
 
   // Default action to execute following M605 mode change commands. Typically G28X to apply new mode.
-  //#define EVENT_GCODE_IDEX_AFTER_MODECHANGE "G28X"
+  #define EVENT_GCODE_IDEX_AFTER_MODECHANGE "G28X"
 #endif
 
 /**
@@ -889,7 +889,9 @@
 //#define HOMING_BACKOFF_POST_MM { 2, 2, 2 }  // (linear=mm, rotational=°) Backoff from endstops after homing
 //#define XY_COUNTERPART_BACKOFF_MM 0         // (mm) Backoff X after homing Y, and vice-versa
 
-#define QUICK_HOME                          // If G28 contains XY do a diagonal move first
+// WARNING: Enabling QUICK_HOME seems to break homing both extruders!
+// This can cause extruder collision - very bad im need!!
+//#define QUICK_HOME                          // If G28 contains XY do a diagonal move first
 //#define HOME_Y_BEFORE_X                     // If G28 contains XY home Y before X
 //#define HOME_Z_FIRST                        // Home Z first. Requires a Z-MIN endstop (not a probe).
 //#define CODEPENDENT_XY_HOMING               // If X/Y can't home without homing Y/X first

--- a/Marlin/Version.h
+++ b/Marlin/Version.h
@@ -28,7 +28,7 @@
 /**
  * Marlin release version identifier
  */
-//#define SHORT_BUILD_VERSION "bugfix-2.1.x"
+#define SHORT_BUILD_VERSION "hpa-2024.06.28"
 
 /**
  * Verbose version identifier which should contain a reference to the location

--- a/Marlin/src/feature/powerloss.cpp
+++ b/Marlin/src/feature/powerloss.cpp
@@ -501,7 +501,7 @@ void PrintJobRecovery::resume() {
     }
   #endif
 
-  if((dualXPrintingModeStatus == 0) || (dualXPrintingModeStatus == 4)) 
+  if (dxc_is_single(dualXPrintingModeStatus))
   {
       sprintf_P(cmd, PSTR("T%i"), info.active_extruder);
       gcode.process_subcommands_now(cmd);

--- a/Marlin/src/lcd/e3v2/creality/LCD_RTS.cpp
+++ b/Marlin/src/lcd/e3v2/creality/LCD_RTS.cpp
@@ -1,5 +1,5 @@
-#include "lcd_rts.h"
-#include <wstring.h>
+#include "LCD_RTS.h"
+#include <WString.h>
 #include <stdio.h>
 #include <string.h>
 #include <Arduino.h>

--- a/Marlin/src/lcd/e3v2/creality/LCD_RTS.cpp
+++ b/Marlin/src/lcd/e3v2/creality/LCD_RTS.cpp
@@ -57,7 +57,7 @@ float ChangeFilament1Temp = 200;
 
 float current_position_x0_axis = X_MIN_POS;
 float current_position_x1_axis = X2_MAX_POS;
-int StartFlag = 0;   
+int StartFlag = 0;
 int PrintFlag = 0;
 
 int heatway = 0;
@@ -100,7 +100,7 @@ bool PoweroffContinue = false;
 char commandbuf[30];
 bool active_extruder_flag = false;
 
-static int change_page_number = 0; 
+static int change_page_number = 0;
 
 char save_dual_x_carriage_mode = 0;
 
@@ -172,8 +172,8 @@ void RTSSHOW::ShowFilesOnCardPage(int page) {
 
     RTS_SndData(shortFileName, buttonIndex);
 
-    if (!EndsWith(card.longest_filename(), "gcode") && !EndsWith(card.longest_filename(), "GCO") 
-        && !EndsWith(card.longest_filename(), "GCODE")) 
+    if (!EndsWith(card.longest_filename(), "gcode") && !EndsWith(card.longest_filename(), "GCO")
+        && !EndsWith(card.longest_filename(), "GCODE"))
     {
       //change color if dir
       RTS_SndData((unsigned long)0x0400, FilenameNature + (textIndex + 5) * 16);
@@ -329,7 +329,7 @@ void RTSSHOW::RTS_Init()
   active_extruder = active_extruder_font;
   #if ENABLED(DUAL_X_CARRIAGE)
     save_dual_x_carriage_mode = dualXPrintingModeStatus;
-    
+
     if(save_dual_x_carriage_mode == 1)
     {
       RTS_SndData(1, PRINT_MODE_ICON_VP);
@@ -350,7 +350,7 @@ void RTSSHOW::RTS_Init()
       RTS_SndData(5, PRINT_MODE_ICON_VP);
       RTS_SndData(5, SELECT_MODE_ICON_VP);
     }
-    else 
+    else
     {
       RTS_SndData(4, PRINT_MODE_ICON_VP);
       RTS_SndData(4, SELECT_MODE_ICON_VP);
@@ -506,7 +506,7 @@ int RTSSHOW::RTS_RecData()
 		}
 	}while(timeout < 50); /* 超时函数 */
 //	MYSERIAL0.write(0xBB);
-	
+
 	if(frame_flag == true){
 		recdat.head[0] = databuf[0];
 		recdat.head[1] = databuf[1];
@@ -520,9 +520,9 @@ int RTSSHOW::RTS_RecData()
 		return -1;
 	}
     // response for writing byte
-    if ((recdat.len == 0x03) && 
-		((recdat.command == 0x82) || (recdat.command == 0x80)) && 
-		(databuf[4] == 0x4F) && 
+    if ((recdat.len == 0x03) &&
+		((recdat.command == 0x82) || (recdat.command == 0x80)) &&
+		(databuf[4] == 0x4F) &&
 		(databuf[5] == 0x4B)){
 		memset(databuf, 0, sizeof(databuf));
 		recnum = 0;
@@ -865,7 +865,7 @@ void RTSSHOW::RTS_HandleData()
       {
         #if ENABLED(DUAL_X_CARRIAGE)
           save_dual_x_carriage_mode = dualXPrintingModeStatus;
-          
+
           SetExtruderMode(save_dual_x_carriage_mode, true);
 
           RTS_SndData(ExchangePageBase + 34, ExchangepageAddr);
@@ -1381,7 +1381,7 @@ void RTSSHOW::RTS_HandleData()
         AxisUnitMode = 4;
         axis_unit = 100.0;
         RTS_SndData(ExchangePageBase + 58, ExchangepageAddr);
-      } 
+      }
       else if(recdat.data[0] == 1)
       {
         AxisUnitMode = 3;
@@ -1523,7 +1523,7 @@ void RTSSHOW::RTS_HandleData()
       {
         RTS_SndData(ExchangePageBase + 1, ExchangepageAddr);
       }
-            else if (recdat.data[0] == 8) // switch to advanced settings page 
+            else if (recdat.data[0] == 8) // switch to advanced settings page
       {
         RTS_SndData(ExchangePageBase + 83, ExchangepageAddr);
       }
@@ -1531,11 +1531,11 @@ void RTSSHOW::RTS_HandleData()
 
     case ASettingsScreenKey:
       SERIAL_ECHOLNPGM("ASettings Button ID: ", recdat.data[0]);
-      if (recdat.data[0] == 1) // switch to e-steps page 
+      if (recdat.data[0] == 1) // switch to e-steps page
       {
         RTS_SndData(ExchangePageBase + 82, ExchangepageAddr);
       }
-      else if (recdat.data[0] == 2) // switch to flow settings page 
+      else if (recdat.data[0] == 2) // switch to flow settings page
       {
         RTS_SndData(ExchangePageBase + 84, ExchangepageAddr);
       }
@@ -1553,17 +1553,17 @@ void RTSSHOW::RTS_HandleData()
       SERIAL_ECHOLNPGM("PIDScreenkey Button ID: ", recdat.data[0]);
       RTS_SndData(ExchangePageBase + 86, ExchangepageAddr);
       RTS_SndData("                     ", PID_TEXT_OUT_VP);
-      if (recdat.data[0] == 1) // nozzle 1 page 
+      if (recdat.data[0] == 1) // nozzle 1 page
       {
         const heater_id_t hid = (heater_id_t)0;
         thermalManager.PID_autotune(200, hid, 5, 1);
       }
-      else if (recdat.data[0] == 2) // nozzle 2 page 
+      else if (recdat.data[0] == 2) // nozzle 2 page
       {
         const heater_id_t hid = (heater_id_t)1;
         thermalManager.PID_autotune(200, hid, 5, 1);
       }
-      else if (recdat.data[0] == 3) // bed page 
+      else if (recdat.data[0] == 3) // bed page
       {
         const heater_id_t hid = (heater_id_t)-1;
         thermalManager.PID_autotune(60, hid, 5, 1);
@@ -1743,7 +1743,7 @@ void RTSSHOW::RTS_HandleData()
       {
         // Assitant Level , Back Left 5
         if(!planner.has_blocks_queued())
-        {   
+        {
           waitway = 4;
           queue.enqueue_now_P(PSTR("G1 F600 Z3"));
           queue.enqueue_now_P(PSTR("G1 X30 Y275 F3000"));
@@ -1752,14 +1752,14 @@ void RTSSHOW::RTS_HandleData()
         }
       }
        else if (recdat.data[0] == 11)
-      { 
+      {
         waitway = 3;
         RTS_SndData(ExchangePageBase + 40, ExchangepageAddr);
         queue.enqueue_now_P(PSTR("G28 X"));
         queue.enqueue_now_P(PSTR("G34"));
         Update_Time_Value = 0;
         waitway = 0;
-      } 
+      }
       else if (recdat.data[0] == 12) {
         RTS_SndData(ExchangePageBase + 40, ExchangepageAddr);
         queue.enqueue_now_P(PSTR("G28 X"));
@@ -1866,7 +1866,7 @@ void RTSSHOW::RTS_HandleData()
         waitway = 0;
       }
       break;
-    
+
     case ZaxismoveKey:
       if(!planner.has_blocks_queued())
       {
@@ -2153,7 +2153,7 @@ void RTSSHOW::RTS_HandleData()
       {
         #if ENABLED(DUAL_X_CARRIAGE)
           save_dual_x_carriage_mode = dualXPrintingModeStatus;
-          
+
           switch(save_dual_x_carriage_mode)
           {
             case 1:
@@ -2244,8 +2244,8 @@ void RTSSHOW::RTS_HandleData()
         card.getAbsFilenameInCWD(fileInfo.currentFilePath);
         strcat(fileInfo.currentFilePath, card.filename);
 
-        if (!EndsWith(fileInfo.currentFilePath, "gcode") && !EndsWith(fileInfo.currentFilePath, "GCO") 
-        && !EndsWith(fileInfo.currentFilePath, "GCODE")) 
+        if (!EndsWith(fileInfo.currentFilePath, "gcode") && !EndsWith(fileInfo.currentFilePath, "GCO")
+        && !EndsWith(fileInfo.currentFilePath, "GCODE"))
         {
           card.cd(fileInfo.currentFilePath);
           InitCardList();
@@ -2278,11 +2278,11 @@ void RTSSHOW::RTS_HandleData()
       {
         if((0 != dualXPrintingModeStatus) && (4 != dualXPrintingModeStatus))
         {
-          RTS_SndData(dualXPrintingModeStatus, SELECT_MODE_ICON_VP);        
+          RTS_SndData(dualXPrintingModeStatus, SELECT_MODE_ICON_VP);
         }
         else if(4 == dualXPrintingModeStatus)
         {
-          RTS_SndData(5, SELECT_MODE_ICON_VP);  
+          RTS_SndData(5, SELECT_MODE_ICON_VP);
         }
         else
         {
@@ -2291,7 +2291,7 @@ void RTSSHOW::RTS_HandleData()
         RTS_SndData(fileInfo.currentDisplayFilename, PRINT_FILE_TEXT_VP);
         RTS_SndData(ExchangePageBase + 56, ExchangepageAddr);
       }
-      else if (recdat.data[0] == 2) 
+      else if (recdat.data[0] == 2)
       {
         //dir back
         card.cdup();
@@ -2324,7 +2324,7 @@ void RTSSHOW::RTS_HandleData()
 
         save_dual_x_carriage_mode = dualXPrintingModeStatus;
         SERIAL_ECHOLNPGM("dualXPrintingModeStatus: ", dualXPrintingModeStatus);
-        
+
         switch(save_dual_x_carriage_mode)
         {
           case 1:
@@ -2499,7 +2499,7 @@ void RTSSHOW::RTS_HandleData()
         RTS_SndData(change_page_number + ExchangePageBase, ExchangepageAddr);
         if((0 != dualXPrintingModeStatus) && (4 != dualXPrintingModeStatus))
         {
-          RTS_SndData(dualXPrintingModeStatus, PRINT_MODE_ICON_VP);        
+          RTS_SndData(dualXPrintingModeStatus, PRINT_MODE_ICON_VP);
         }
         else if(4 == dualXPrintingModeStatus)
         {
@@ -2515,7 +2515,7 @@ void RTSSHOW::RTS_HandleData()
         RTS_SndData(change_page_number + ExchangePageBase, ExchangepageAddr);
         if((0 != dualXPrintingModeStatus) && (4 != dualXPrintingModeStatus))
         {
-          RTS_SndData(dualXPrintingModeStatus, PRINT_MODE_ICON_VP);        
+          RTS_SndData(dualXPrintingModeStatus, PRINT_MODE_ICON_VP);
         }
         else if(4 == dualXPrintingModeStatus)
         {
@@ -2533,7 +2533,7 @@ void RTSSHOW::RTS_HandleData()
       }
       if((0 != dualXPrintingModeStatus) && (4 != dualXPrintingModeStatus))
       {
-        RTS_SndData(dualXPrintingModeStatus, SELECT_MODE_ICON_VP);        
+        RTS_SndData(dualXPrintingModeStatus, SELECT_MODE_ICON_VP);
       }
       else if(4 == dualXPrintingModeStatus)
       {
@@ -2789,7 +2789,7 @@ void EachMomentUpdate()
     }
     // moved z height output to make sure it is always up to date
     rtscheck.RTS_SndData(10 * current_position[Z_AXIS], AXIS_Z_COORD_VP);
-    
+
     next_rts_update_ms = ms + RTS_UPDATE_INTERVAL + Update_Time_Value;
   }
 }
@@ -2802,8 +2802,8 @@ void SetExtruderMode(unsigned int mode, bool isDirect) {
     mode = 4;
   }
   SERIAL_ECHOLNPGM("Select new extruder mode: ", mode);
-  if (mode == 1)
-  {
+  switch (mode) {
+  case 1:
     //dual mode
     rtscheck.RTS_SndData(1, TWO_COLOR_MODE_ICON_VP);
     rtscheck.RTS_SndData(0, COPY_MODE_ICON_VP);
@@ -2812,9 +2812,9 @@ void SetExtruderMode(unsigned int mode, bool isDirect) {
     dualXPrintingModeStatus = 1;
     rtscheck.RTS_SndData(1, PRINT_MODE_ICON_VP);
     rtscheck.RTS_SndData(1, SELECT_MODE_ICON_VP);
-  }
-  else if (mode == 2)
-  {
+    break;
+
+  case 2:
     //duplicate mode
     rtscheck.RTS_SndData(1, COPY_MODE_ICON_VP);
     rtscheck.RTS_SndData(0, TWO_COLOR_MODE_ICON_VP);
@@ -2823,9 +2823,9 @@ void SetExtruderMode(unsigned int mode, bool isDirect) {
     dualXPrintingModeStatus = 2;
     rtscheck.RTS_SndData(2, PRINT_MODE_ICON_VP);
     rtscheck.RTS_SndData(2, SELECT_MODE_ICON_VP);
-  }
-  else if (mode == 3)
-  {
+    break;
+
+  case 3:
     //mirror mode
     rtscheck.RTS_SndData(1, MIRROR_MODE_ICON_VP);
     rtscheck.RTS_SndData(0, TWO_COLOR_MODE_ICON_VP);
@@ -2834,9 +2834,10 @@ void SetExtruderMode(unsigned int mode, bool isDirect) {
     dualXPrintingModeStatus = 3;
     rtscheck.RTS_SndData(3, PRINT_MODE_ICON_VP);
     rtscheck.RTS_SndData(3, SELECT_MODE_ICON_VP);
-  }
-  else if (mode == 4)
-  {
+    break;
+
+  case 4:
+  default:
     //single 1 mode
     rtscheck.RTS_SndData(0, MIRROR_MODE_ICON_VP);
     rtscheck.RTS_SndData(0, TWO_COLOR_MODE_ICON_VP);
@@ -2845,9 +2846,9 @@ void SetExtruderMode(unsigned int mode, bool isDirect) {
     dualXPrintingModeStatus = 0;
     rtscheck.RTS_SndData(4, PRINT_MODE_ICON_VP);
     rtscheck.RTS_SndData(4, SELECT_MODE_ICON_VP);
-  }
-  else if (mode == 5)
-  {
+    break;
+
+  case 5:
     //single 2 mode
     rtscheck.RTS_SndData(0, MIRROR_MODE_ICON_VP);
     rtscheck.RTS_SndData(0, TWO_COLOR_MODE_ICON_VP);
@@ -2856,21 +2857,14 @@ void SetExtruderMode(unsigned int mode, bool isDirect) {
     dualXPrintingModeStatus = 4;
     rtscheck.RTS_SndData(5, PRINT_MODE_ICON_VP);
     rtscheck.RTS_SndData(5, SELECT_MODE_ICON_VP);
-  } else if (mode == 6)
-  {
+    break;
+
+  case 6:
     save_dual_x_carriage_mode = dualXPrintingModeStatus;
     //SERIAL_ECHOLNPGM("save_dual_x_carriage_mode: ", save_dual_x_carriage_mode);
     settings.save();
     rtscheck.RTS_SndData(ExchangePageBase + 1, ExchangepageAddr);
-  } else {
-    //single 1 mode
-    rtscheck.RTS_SndData(0, MIRROR_MODE_ICON_VP);
-    rtscheck.RTS_SndData(0, TWO_COLOR_MODE_ICON_VP);
-    rtscheck.RTS_SndData(0, COPY_MODE_ICON_VP);
-    rtscheck.RTS_SndData(1, SINGLE_MODE_ICON_VP);
-    dualXPrintingModeStatus = 0;
-    rtscheck.RTS_SndData(4, PRINT_MODE_ICON_VP);
-    rtscheck.RTS_SndData(4, SELECT_MODE_ICON_VP);
+    break;
   }
 }
 
@@ -2884,7 +2878,7 @@ void RTSUpdate()
 	card_insert_st = IS_SD_INSERTED() ;
 
 	if((card_insert_st == false) && (sd_printing == true)){
-		rtscheck.RTS_SndData(ExchangePageBase + 46, ExchangepageAddr);	
+		rtscheck.RTS_SndData(ExchangePageBase + 46, ExchangepageAddr);
 		rtscheck.RTS_SndData(0, CHANGE_SDCARD_ICON_VP);
 		/* 暂停打印，使得喷头可以回到零点 */
 		card.pauseSDPrint();
@@ -2900,7 +2894,7 @@ void RTSUpdate()
 		rtscheck.RTS_SndData((int)card_insert_st, CHANGE_SDCARD_ICON_VP);
 		last_card_insert_st = card_insert_st;
 	}
-  
+
   EachMomentUpdate();
   // wait to receive massage and response
   while(rtscheck.RTS_RecData() > 0)
@@ -2939,19 +2933,19 @@ void RTS_MoveAxisHoming()
     if(AxisUnitMode == 4)
     {
       rtscheck.RTS_SndData(ExchangePageBase + 58, ExchangepageAddr);
-    } 
+    }
     else if(AxisUnitMode == 3)
     {
       rtscheck.RTS_SndData(ExchangePageBase + 29, ExchangepageAddr);
-    } 
+    }
     else if(AxisUnitMode == 2)
     {
       rtscheck.RTS_SndData(ExchangePageBase + 30, ExchangepageAddr);
-    } 
+    }
     else if(AxisUnitMode == 1)
     {
       rtscheck.RTS_SndData(ExchangePageBase + 31, ExchangepageAddr);
-    } 
+    }
     waitway = 0;
   }
   else if(waitway == 6)

--- a/Marlin/src/lcd/e3v2/creality/LCD_RTS.h
+++ b/Marlin/src/lcd/e3v2/creality/LCD_RTS.h
@@ -3,7 +3,7 @@
 
 #include "../../../sd/cardreader.h"
 #include "string.h"
-#include <arduino.h>
+#include <Arduino.h>
 
 #include "../../../inc/MarlinConfig.h"
 

--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -1338,11 +1338,6 @@ FORCE_INLINE void segment_idle(millis_t &next_idle_ms) {
   inline bool dual_x_carriage_unpark() {
     if (active_extruder_parked) {
       switch (dual_x_carriage_mode) {
-
-        case DXC_SINGLE_2:
-        case DXC_FULL_CONTROL_MODE: 
-          break;
-
         case DXC_AUTO_PARK_MODE: {
           if (current_position.e == destination.e) {
             // This is a travel move (with no extrusion)
@@ -1404,6 +1399,9 @@ FORCE_INLINE void segment_idle(millis_t &next_idle_ms) {
             if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("set_duplication_enabled(true)\nidex_set_parked(false)");
           }
           else if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("Active extruder not 0");
+          break;
+
+        default:
           break;
       }
     }

--- a/Marlin/src/module/settings.cpp
+++ b/Marlin/src/module/settings.cpp
@@ -2634,17 +2634,13 @@ void MarlinSettings::postprocess() {
       }
       #endif
 
-      if((dualXPrintingModeStatus != 0) && (dualXPrintingModeStatus != 1) && (dualXPrintingModeStatus != 2) && (dualXPrintingModeStatus != 3) && (dualXPrintingModeStatus != 4))
-      {
-        dualXPrintingModeStatus = 0;
-      }
       EEPROM_READ(dualXPrintingModeStatus);
+      if (dualXPrintingModeStatus > DXC_MAX_MODE)
+        dualXPrintingModeStatus = DEFAULT_DUAL_X_CARRIAGE_MODE;
 
-      if((active_extruder_font != 0) && (active_extruder_font != 1))
-      {
-        active_extruder_font = 0;
-      }
       EEPROM_READ(active_extruder_font);
+      if (active_extruder_font > 1)
+        active_extruder_font = 0;
 
       //
       // Model predictive control

--- a/Marlin/src/module/tool_change.cpp
+++ b/Marlin/src/module/tool_change.cpp
@@ -844,11 +844,10 @@ void fast_line_to_current(const AxisEnum fr_axis) { _line_to_current(fr_axis, 0.
 
     DEBUG_ECHOPGM("Dual X Carriage Mode ");
     switch (dual_x_carriage_mode) {
-      case DXC_FULL_CONTROL_MODE: DEBUG_ECHOLNPGM("FULL_CONTROL"); break;
+      default: DEBUG_ECHOLNPGM("FULL_CONTROL E", dxc_extruder_index()); break;
       case DXC_AUTO_PARK_MODE:    DEBUG_ECHOLNPGM("AUTO_PARK");    break;
       case DXC_DUPLICATION_MODE:  DEBUG_ECHOLNPGM("DUPLICATION");  break;
       case DXC_MIRRORED_MODE:     DEBUG_ECHOLNPGM("MIRRORED");     break;
-      case DXC_SINGLE_2:          DEBUG_ECHOLNPGM("SINGLE MODE 2"); break;
     }
 
     // Get the home position of the currently-active tool

--- a/Marlin/src/pins/stm32f1/pins_CREALITY_V521.h
+++ b/Marlin/src/pins/stm32f1/pins_CREALITY_V521.h
@@ -230,3 +230,11 @@
 #if HAS_DGUS_LCD
   #define LCD_SERIAL_PORT                      3
 #endif
+
+// Optional suicide pin based on Bjoern70's standard (connector J2, active low)
+#ifndef SUICIDE_PIN
+ #define SUICIDE_PIN                  PE4
+#endif
+#ifndef SUICIDE_PIN_STATE
+ #define SUICIDE_PIN_STATE            LOW
+#endif


### PR DESCRIPTION
- Fix building LCD_RTS on case-sensitive systems (Unix)
- Enable using the J2 header on the SV04 as a suicide switch, as per bjoern70's design and my remix thereof.